### PR TITLE
Feature/auto buildnr

### DIFF
--- a/Vialer.xcodeproj/project.pbxproj
+++ b/Vialer.xcodeproj/project.pbxproj
@@ -972,7 +972,8 @@
 				FB4226C9182261D200707349 /* Sources */,
 				FB4226CA182261D200707349 /* Frameworks */,
 				FB4226CB182261D200707349 /* Resources */,
-				F217146F1B54F4F00078B0A0 /* Update Build version */,
+				F298A9741B5E28D100467E31 /* Update Version number */,
+				F217146F1B54F4F00078B0A0 /* Update Build number */,
 				3D1A5E8E1AE6308500DBE64B /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -1072,20 +1073,34 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		F217146F1B54F4F00078B0A0 /* Update Build version */ = {
+		F217146F1B54F4F00078B0A0 /* Update Build number */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Update Build version";
+			name = "Update Build number";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = $SRCROOT/scripts/update_build_number.sh;
 			showEnvVarsInLog = 0;
+		};
+		F298A9741B5E28D100467E31 /* Update Version number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update Version number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/scripts/update_version_number.sh master";
 		};
 		F2B947311B00DFEC00CE5112 /* config_site.h copy script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Vialer.xcodeproj/project.pbxproj
+++ b/Vialer.xcodeproj/project.pbxproj
@@ -972,6 +972,7 @@
 				FB4226C9182261D200707349 /* Sources */,
 				FB4226CA182261D200707349 /* Frameworks */,
 				FB4226CB182261D200707349 /* Resources */,
+				F217146F1B54F4F00078B0A0 /* Update Build version */,
 				3D1A5E8E1AE6308500DBE64B /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -1071,6 +1072,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		F217146F1B54F4F00078B0A0 /* Update Build version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update Build version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = $SRCROOT/scripts/update_build_number.sh;
+			showEnvVarsInLog = 0;
+		};
 		F2B947311B00DFEC00CE5112 /* config_site.h copy script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Vialer/AdHocDistribution-Info.plist
+++ b/Vialer/AdHocDistribution-Info.plist
@@ -25,7 +25,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.3</string>
+	<string>Updated on build</string>
+	<key>Commit_Short_Hash</key>
+	<string>Updated on build</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/Vialer/AdHocDistribution-Info.plist
+++ b/Vialer/AdHocDistribution-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3</string>
+	<string>Updated on build</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Vialer/AppDelegate.m
+++ b/Vialer/AppDelegate.m
@@ -58,18 +58,8 @@
     }
 }
 
-- (NSString *)appVersion {
-    NSDictionary *infoDict = [NSBundle mainBundle].infoDictionary;
-    NSString *version = [NSString stringWithFormat:@"Version:%@ - Build:%@ Commit:%@",
-                         [infoDict objectForKey:@"CFBundleShortVersionString"],
-                         [infoDict objectForKey:@"CFBundleVersion"],
-                         [infoDict objectForKey:@"Commit_Short_Hash"]];
-    return version;
-}
-
 #pragma mark - UIApplication delegate
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    NSLog(@"%@", [self appVersion]);
     
     [self doRegistrationWithLoginCheck];
     [application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];

--- a/Vialer/AppDelegate.m
+++ b/Vialer/AppDelegate.m
@@ -58,9 +58,19 @@
     }
 }
 
+- (NSString *)appVersion {
+    NSDictionary *infoDict = [NSBundle mainBundle].infoDictionary;
+    NSString *version = [NSString stringWithFormat:@"Version:%@ - Build:%@ Commit:%@",
+                         [infoDict objectForKey:@"CFBundleShortVersionString"],
+                         [infoDict objectForKey:@"CFBundleVersion"],
+                         [infoDict objectForKey:@"Commit_Short_Hash"]];
+    return version;
+}
+
 #pragma mark - UIApplication delegate
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-   
+    NSLog(@"%@", [self appVersion]);
+    
     [self doRegistrationWithLoginCheck];
     [application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
     

--- a/Vialer/LogInViewController.m
+++ b/Vialer/LogInViewController.m
@@ -319,7 +319,12 @@
 - (void)setLockScreenFriendlyNameWithResponse:(id)responseObject {
     if ([responseObject isKindOfClass:[NSDictionary class]]) {
         NSDictionary *userDict = (NSDictionary*)responseObject;
-        NSString *greeting = [NSString stringWithFormat:@"%@ %@!", userDict[@"first_name"], userDict[@"last_name"]];
+        NSString *firstName = userDict[@"first_name"];
+        NSString *lastName = userDict[@"last_name"];
+        NSString *greeting;
+        if (firstName && lastName)
+            greeting = [NSString stringWithFormat:@"%@ %@!", userDict[@"first_name"], userDict[@"last_name"]];
+
         [self.unlockView.greetingsLabel setText:greeting];
     }
 }

--- a/Vialer/SideMenuViewController.m
+++ b/Vialer/SideMenuViewController.m
@@ -101,10 +101,35 @@
         [headerView addSubview:logo];
         [headerView addSubview:numberLabel];
         
+#ifdef DEBUG
+        yOffset = CGRectGetMaxY(headerView.bounds) - 18.f;
+        CGRect versionBuildLabelFrame = CGRectMake(0, yOffset, CGRectGetWidth(headerView.frame), 20.f);
+        [headerView addSubview:[self versionBuildLabel:versionBuildLabelFrame]];
+#endif
+        
         return headerView;
     } else {
         return nil;
     }
+}
+
+- (UILabel *)versionBuildLabel:(CGRect)frame {
+    UILabel *versionBuildLabel = [[UILabel alloc] initWithFrame:frame];
+    versionBuildLabel.font = [UIFont systemFontOfSize:10.f];
+    versionBuildLabel.textAlignment = NSTextAlignmentCenter;
+    versionBuildLabel.textColor = [UIColor darkGrayColor];
+    versionBuildLabel.text = [self  appVersionBuildString];
+        
+    return versionBuildLabel;
+}
+
+- (NSString *)appVersionBuildString {
+    NSDictionary *infoDict = [NSBundle mainBundle].infoDictionary;
+    NSString *version = [NSString stringWithFormat:@"Version:%@  Build:%@  Commit:%@",
+                         [infoDict objectForKey:@"CFBundleShortVersionString"],
+                         [infoDict objectForKey:@"CFBundleVersion"],
+                         [infoDict objectForKey:@"Commit_Short_Hash"]];
+    return version;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {

--- a/Vialer/Vialer-Info.plist
+++ b/Vialer/Vialer-Info.plist
@@ -21,10 +21,12 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3</string>
+	<string>Updated on build</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
+	<string>Updated on build</string>
+	<key>Commit_Short_Hash</key>
 	<string>Updated on build</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
@@ -57,8 +59,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>Commit_Short_Hash</key>
-	<string>Updated on build</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/Vialer/Vialer-Info.plist
+++ b/Vialer/Vialer-Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.3</string>
+	<string>Updated on build</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIBackgroundModes</key>
@@ -57,6 +57,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>Commit_Short_Hash</key>
+	<string>Updated on build</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/scripts/buildnr_to_commit_hash.sh
+++ b/scripts/buildnr_to_commit_hash.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+ 
+#  nth-commit.sh
+#  Usage: 'buildnr_to_commit_hash.sh [buildnumber] [branch]'
+#  Based on: http://tgoode.com/2014/06/05/sensible-way-increment-bundle-version-cfbundleversion-xcode/#code
+ 
+GIT=`sh /etc/profile; which git`
+BUILDNUMBER=${1}
+BRANCH=${2}
+
+if [ -z $BRANCH ]; then
+  echo "Usage:"
+  echo "  buildnr_to_commit_hash.sh [buildnumber] [branch]"
+else
+  echo "Using branch '${BRANCH}' for counting"
+
+  SHA1=$(${GIT} rev-list ${BRANCH} | tail -n ${BUILDNUMBER} | head -n 1)
+  echo "use: 'git checkout $SHA1' to get the commit for buildnumber: ${BUILDNUMBER}"
+fi

--- a/scripts/update_build_number.sh
+++ b/scripts/update_build_number.sh
@@ -8,6 +8,7 @@
 #    http://blog.jaredsinclair.com/post/97193356620/the-best-of-all-possible-xcode-automated-build
 #    http://www.egeek.me/2013/02/09/xcode-insert-git-build-info-into-ios-app/
 
+#  Consider using https://github.com/Autorevision/autorevision for both Verion and Build number  
  
 GIT=`sh /etc/profile; which git`
 PLISTBUDDY=/usr/libexec/PlistBuddy
@@ -32,5 +33,6 @@ echo "Commit short hash:${COMMIT_SHORT_HASH}"
 #  the info.plist in the target build directory. This way, you don’t have to check-in a 
 #  constantly-modifying info.plist.
 ${PLISTBUDDY} -c "Set :CFBundleVersion ${BUILDNUMBER}" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
-${PLISTBUDDY} -c "Set :CFBundleVersion ${BUILDNUMBER}" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist"
+#Also update dSYM file
+${PLISTBUDDY} -c "Set :CFBundleVersion ${BUILDNUMBER}" "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist"
 ${PLISTBUDDY} -c "Set :Commit_Short_Hash ${COMMIT_SHORT_HASH}" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"

--- a/scripts/update_build_number.sh
+++ b/scripts/update_build_number.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+ 
+#  update_build_number.sh
+#  Usage: `update_build_number.sha [branch]`
+#  Run this script after the 'Copy Bundle Resources' build phase
+#  Based on:
+#    http://tgoode.com/2014/06/05/sensible-way-increment-bundle-version-cfbundleversion-xcode/#code
+#    http://blog.jaredsinclair.com/post/97193356620/the-best-of-all-possible-xcode-automated-build
+#    http://www.egeek.me/2013/02/09/xcode-insert-git-build-info-into-ios-app/
+
+ 
+GIT=`sh /etc/profile; which git`
+PLISTBUDDY=/usr/libexec/PlistBuddy
+
+#Use the argument supplied branch or otherwise the current branch
+BRANCH=${1:-`${GIT} rev-parse --abbrev-ref HEAD`}
+echo "Using branch '${BRANCH}' for counting"
+
+#  git rev-list ${BRANCH} --count is used to get the number of commits on ${BRANCH}, 
+#  BUT it subtracts out the number of commits that you are currently behind said branch 
+#  (with git rev-list HEAD..${BRANCH} --count). 
+#  This is done so that if you aren’t at the tip of the branch (e.g. you’re checked out 
+#  a few commits behind to find a problem), the build number will still be accurate to 
+#  what you’re currently running.
+BUILDNUMBER=$(expr $(${GIT} rev-list ${BRANCH} --count) - $(${GIT} rev-list HEAD..${BRANCH} --count))
+echo "Updating build number to ${BUILDNUMBER} using branch '${BRANCH}'."
+
+COMMIT_SHORT_HASH=$(${GIT} rev-list ${BRANCH} --abbrev-commit | tail -n ${BUILDNUMBER} | head -n 1)
+echo "Commit short hash:${COMMIT_SHORT_HASH}"
+
+#  Instead of updating the info.plist file in the source directory, the script modifies 
+#  the info.plist in the target build directory. This way, you don’t have to check-in a 
+#  constantly-modifying info.plist.
+${PLISTBUDDY} -c "Set :CFBundleVersion ${BUILDNUMBER}" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
+${PLISTBUDDY} -c "Set :CFBundleVersion ${BUILDNUMBER}" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist"
+${PLISTBUDDY} -c "Set :Commit_Short_Hash ${COMMIT_SHORT_HASH}" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"

--- a/scripts/update_version_number.sh
+++ b/scripts/update_version_number.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#  update_version_number.sh
+#  Usage: `update_version_number [branch]`
+#
+#  Based on:
+#    http://zargony.com/2014/08/10/automatic-versioning-in-xcode-with-git-describe
+
+#  Consider using https://github.com/Autorevision/autorevision for both Verion and Build number
+
+GIT=`sh /etc/profile; which git`
+PLISTBUDDY=/usr/libexec/PlistBuddy
+BRANCH=${1}
+
+VERSION_NUMBER=`${GIT} describe ${BRANCH}`
+echo "Version number: ${VERSION_NUMBER}"
+
+${PLISTBUDDY} -c "Set :CFBundleShortVersionString ${VERSION_NUMBER}" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
+#Also update dSYM file
+${PLISTBUDDY} -c "Set :CFBundleShortVersionString ${VERSION_NUMBER}" "${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}.dSYM/Contents/Info.plist"


### PR DESCRIPTION
The projects Version (CFBundleShortVersionString) and Build () number is now updated through 2 scripts at build time. The relevant info.plist file in the project it self is NOT updated as this would lead to files changing after a commit. Instead, the info.plist files of the actual build is edited.

This version information is show in the header of the side menu but only when DEBUG is set.