### PR TITLE
feature/incoming-call-failed-original-call-hangup-3480

### DIFF
--- a/Vialer/AppDelegate.swift
+++ b/Vialer/AppDelegate.swift
@@ -265,6 +265,7 @@ extension AppDelegate {
             case .originatorCancel:
                 VialerLogDebug("Originator cancelled")
                 VialerGAITracker.missedIncomingCallOriginatorCancelledEvent()
+                VialerStats.sharedInstance.incomingCallFailedOriginatorCanceled(call: call)
             case .unknown:
                 break
             }

--- a/Vialer/Helpers/VialerStats.swift
+++ b/Vialer/Helpers/VialerStats.swift
@@ -153,16 +153,39 @@ import Foundation
     }
     
     @objc func incomingCallFailedAfterEightPushNotifications(timeToInitialReport: Double){
+        initDefaultData()
+        
         guard !VialerStats.sharedInstance.middlewareUniqueKey.isEmpty else {
             return
         }
+        defaultData[VialerStatsConstants.APIKeys.middlewareUniqueKey] = VialerStats.sharedInstance.middlewareUniqueKey
+        
         self.setNetworkData()
+        setTransportData()
+        self.setCallDirection(true)
 
-        defaultData[VialerStatsConstants.APIKeys.direction] = VialerStatsConstants.Direction.inbound
         defaultData[VialerStatsConstants.APIKeys.callSetupSuccessful] = "false"
         defaultData[VialerStatsConstants.APIKeys.failedReason] = "INSUFFICIENT_NETWORK"
         defaultData[VialerStatsConstants.APIKeys.timeToInitialResponse] = String(timeToInitialReport)
-        defaultData.removeValue(forKey: VialerStatsConstants.APIKeys.attempt)
+        
+        sendMetrics()
+    }
+    
+    @objc func incomingCallFailedOriginatorCanceled(call: VSLCall){
+        initDefaultData()
+        
+        guard !VialerStats.sharedInstance.middlewareUniqueKey.isEmpty else {
+            return
+        }
+        defaultData[VialerStatsConstants.APIKeys.middlewareUniqueKey] = VialerStats.sharedInstance.middlewareUniqueKey
+        
+        self.setNetworkData()
+        setTransportData()
+        self.setCallDirection(true)
+        
+        defaultData[VialerStatsConstants.APIKeys.callSetupSuccessful] = "false"
+        defaultData[VialerStatsConstants.APIKeys.failedReason] = "ORIGINATOR_CANCELED"
+        defaultData[VialerStatsConstants.APIKeys.asteriskCallId] = call.messageCallId
         
         sendMetrics()
     }
@@ -213,7 +236,7 @@ import Foundation
 
     // Send the metrics to the middleware
     private func sendMetrics() {
-        // Add the remote logging id to the data if it is present`
+        // Add the remote logging id to the data if it is present
         if VialerLogger.remoteLoggingEnabled() {
             defaultData[VialerStatsConstants.APIKeys.remoteLogId] = VialerLogger.remoteIdentifier()
         }


### PR DESCRIPTION
Added func incomingCallFailedOriginatorCanceled and called it on AppDelegate, also applied some changes on VialerStats class

### Issue number
VIALI-3480

### Expected behaviour

### Actual behaviour

### Description of fix
sending stats to middleware about when an incoming call failed because the originator cancelled it 

### Other info
applied some changes on VialerStats class
