### PR TITLE
Feature/incoming call failed declined because of call already in progress 3477

### DIFF
--- a/Branding/ANNAbel/ANNAbel-Info.plist
+++ b/Branding/ANNAbel/ANNAbel-Info.plist
@@ -40,6 +40,8 @@
 	<string>ANNAbel needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>ANNAbel needs access to your microphone to make calling possible</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>ANNAbel needs access to your bluetooth devices&apos; data to log the name of the audio bluetooth device which is being used</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Branding/ANNAbel/en.lproj/InfoPlist.strings
+++ b/Branding/ANNAbel/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSContactsUsageDescription = "ANNAbel needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.";
 NSMicrophoneUsageDescription = "ANNAbel needs access to your microphone to make calling possible";
 NSCameraUsageDescription = "ANNAbel needs access to your camera to make video calls";
+NSBluetoothPeripheralUsageDescription = "ANNAbel needs access to your bluetooth devices' data to log the name of the audio bluetooth device which is being used";

--- a/Branding/ANNAbel/nl.lproj/InfoPlist.strings
+++ b/Branding/ANNAbel/nl.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 NSContactsUsageDescription = "ANNAbel heeft toegang tot uw contacten nodig om bellen mogelijk te maken. Uw contacten worden niet door ons gebruikt or ergens anders bewaard. Alleen het telefoonnummer en de naam worden gebruikt om een gesprek op te zetten.";
 NSMicrophoneUsageDescription = "ANNAbel heeft toegang nodig tot je microfoon om bellen mogelijk te maken";
 NSCameraUsageDescription = "ANNAbel heeft toegang nodig tot je camera om video bellen mogelijk te maken";
-
+NSBluetoothPeripheralUsageDescription = "ANNAbel heeft toegang naar de bluetooth module van dit apparaat nodig om de naam van het bluetooth audio apparaat te kunnen loggen";

--- a/Branding/Acceptatie/Vialer/Acceptatie-Info.plist
+++ b/Branding/Acceptatie/Vialer/Acceptatie-Info.plist
@@ -40,6 +40,8 @@
 	<string>Vialer needs access to your contacts to make calling to your contacts possible</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Vialer needs access to your microphone to make calling possible</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Vialer needs access to your bluetooth devices&apos; data to log the name of the audio bluetooth device which is being used</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Branding/Acceptatie/Voys/Acceptatie-Voys-Info.plist
+++ b/Branding/Acceptatie/Voys/Acceptatie-Voys-Info.plist
@@ -40,6 +40,8 @@
 	<string>Voys needs access to your contacts to make calling to your contacts possible</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Voys needs access to your microphone to make calling possible</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Voys needs access to your bluetooth devices&apos; data to log the name of the audio bluetooth device which is being used</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Branding/Verbonden/Verbonden-Info.plist
+++ b/Branding/Verbonden/Verbonden-Info.plist
@@ -38,6 +38,8 @@
 	<string>Verbonden needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Verbonden needs access to your microphone to make calling possible</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Verbonden needs access to your bluetooth devices&apos; data to log the name of the audio bluetooth device which is being used</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Branding/Verbonden/en.lproj/InfoPlist.strings
+++ b/Branding/Verbonden/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSContactsUsageDescription = "Verbonden needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.";
 NSMicrophoneUsageDescription = "Verbonden needs access to your microphone to make calling possible";
 NSCameraUsageDescription= "Verbonden needs access to your camera to make video calls";
+NSBluetoothPeripheralUsageDescription = "Verbonden needs access to your bluetooth devices' data to log the name of the audio bluetooth device which is being used";

--- a/Branding/Verbonden/nl.lproj/InfoPlist.strings
+++ b/Branding/Verbonden/nl.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSContactsUsageDescription = "Verbonden heeft toegang tot uw contacten nodig om bellen mogelijk te maken. Uw contacten worden niet door ons gebruikt or ergens anders bewaard. Alleen het telefoonnummer en de naam worden gebruikt om een gesprek op te zetten.";
 NSMicrophoneUsageDescription = "Verbonden heeft toegang nodig tot je microfoon om bellen mogelijk te maken";
 NSCameraUsageDescription = "Verbonden heeft toegang nodig tot je camera om video bellen mogelijk te maken";
+NSBluetoothPeripheralUsageDescription = "Verbonden heeft toegang naar de bluetooth module van dit apparaat nodig om de naam van het bluetooth audio apparaat te kunnen loggen";

--- a/Branding/Vialer/Vialer-Info.plist
+++ b/Branding/Vialer/Vialer-Info.plist
@@ -38,6 +38,8 @@
 	<string>Vialer needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Vialer needs access to your microphone to make calling possible</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Vialer needs access to your bluetooth devices&apos; data to log the name of the audio bluetooth device which is being used</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Branding/Vialer/en.lproj/InfoPlist.strings
+++ b/Branding/Vialer/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSContactsUsageDescription = "Vialer needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.";
 NSMicrophoneUsageDescription = "Vialer needs access to your microphone to make calling possible";
 NSCameraUsageDescription= "Vialer needs access to your camera to make video calls";
+NSBluetoothPeripheralUsageDescription = "Vialer needs access to your bluetooth devices' data to log the name of the audio bluetooth device which is being used";

--- a/Branding/Vialer/nl.lproj/InfoPlist.strings
+++ b/Branding/Vialer/nl.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSContactsUsageDescription = "Vialer heeft toegang tot uw contacten nodig om bellen mogelijk te maken. Uw contacten worden niet door ons gebruikt or ergens anders bewaard. Alleen het telefoonnummer en de naam worden gebruikt om een gesprek op te zetten.";
 NSMicrophoneUsageDescription = "Vialer heeft toegang nodig tot je microfoon om bellen mogelijk te maken";
 NSCameraUsageDescription = "Vialer heeft toegang nodig tot je camera om video bellen mogelijk te maken";
+NSBluetoothPeripheralUsageDescription = "Vialer heeft toegang naar de bluetooth module van dit apparaat nodig om de naam van het bluetooth audio apparaat te kunnen loggen."

--- a/Branding/Vialer/nl.lproj/InfoPlist.strings
+++ b/Branding/Vialer/nl.lproj/InfoPlist.strings
@@ -1,4 +1,4 @@
 NSContactsUsageDescription = "Vialer heeft toegang tot uw contacten nodig om bellen mogelijk te maken. Uw contacten worden niet door ons gebruikt or ergens anders bewaard. Alleen het telefoonnummer en de naam worden gebruikt om een gesprek op te zetten.";
 NSMicrophoneUsageDescription = "Vialer heeft toegang nodig tot je microfoon om bellen mogelijk te maken";
 NSCameraUsageDescription = "Vialer heeft toegang nodig tot je camera om video bellen mogelijk te maken";
-NSBluetoothPeripheralUsageDescription = "Vialer heeft toegang naar de bluetooth module van dit apparaat nodig om de naam van het bluetooth audio apparaat te kunnen loggen."
+NSBluetoothPeripheralUsageDescription = "Vialer heeft toegang naar de bluetooth module van dit apparaat nodig om de naam van het bluetooth audio apparaat te kunnen loggen";

--- a/Branding/Voys/Voys-Info.plist
+++ b/Branding/Voys/Voys-Info.plist
@@ -40,6 +40,8 @@
 	<string>Voys needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Voys needs access to your microphone to make calling possible</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Voys needs access to your bluetooth devices&apos; data to log the name of the audio bluetooth device which is being used</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/Branding/Voys/en.lproj/InfoPlist.strings
+++ b/Branding/Voys/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSContactsUsageDescription = "Voys needs access to your contacts to make calls to your contacts possible. Your contacts will not be used by us or uploaded anywhere. Only the phone number and name are used to setup a call.";
 NSMicrophoneUsageDescription = "Voys needs access to your microphone to make calling possible";
 NSCameraUsageDescription = "Voys needs access to your camera to make video calls";
+NSBluetoothPeripheralUsageDescription = "Voys needs access to your bluetooth devices' data to log the name of the audio bluetooth device which is being used";

--- a/Branding/Voys/nl.lproj/InfoPlist.strings
+++ b/Branding/Voys/nl.lproj/InfoPlist.strings
@@ -1,4 +1,5 @@
 NSContactsUsageDescription = "Voys heeft toegang tot uw contacten nodig om bellen mogelijk te maken. Uw contacten worden niet door ons gebruikt or ergens anders bewaard. Alleen het telefoonnummer en de naam worden gebruikt om een gesprek op te zetten.";
 NSMicrophoneUsageDescription = "Voys heeft toegang nodig tot je microfoon om bellen mogelijk te maken";
 NSCameraUsageDescription = "Voys heeft toegang nodig tot je camera om video bellen mogelijk te maken";
+NSBluetoothPeripheralUsageDescription = "Voys heeft toegang naar de bluetooth module van dit apparaat nodig om de naam van het bluetooth audio apparaat te kunnen loggen";
 

--- a/Vialer.xcodeproj/project.pbxproj
+++ b/Vialer.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		61C1C91605D6974E2A2BB4E6 /* libPods-Acceptatie.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EAD7089BF0A00A41F5AA8FE /* libPods-Acceptatie.a */; };
 		644BC2453E4782C0BF5C0CAB /* libPods-Vialer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CF5A80F00FD008B22FF87BE8 /* libPods-Vialer.a */; };
 		7273048195AF10B9406CDD0A /* libPods-Acceptatie Voys.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C5A3A0941590C7F7200913A /* libPods-Acceptatie Voys.a */; };
+		836884AD20F4B4290098A961 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 836884AC20F4B4290098A961 /* CoreBluetooth.framework */; };
+		836884AE20F4B43A0098A961 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 836884AC20F4B4290098A961 /* CoreBluetooth.framework */; };
+		836884AF20F4B4490098A961 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 836884AC20F4B4290098A961 /* CoreBluetooth.framework */; };
+		836884B020F4B4580098A961 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 836884AC20F4B4290098A961 /* CoreBluetooth.framework */; };
 		872A659476081865A971CEEF /* libPods-ANNAbelSnapshotUITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AEBCFBF586B140C9FD3D42B4 /* libPods-ANNAbelSnapshotUITests.a */; };
 		A89BBA46A7258849FB9B1083 /* libPods-VialerTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 575B8E9FB91EC90046F32E7F /* libPods-VialerTests.a */; };
 		C4052E561E2F64FE00F45B9C /* String+regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4052E551E2F64FE00F45B9C /* String+regex.swift */; };
@@ -1185,6 +1189,7 @@
 		7AB7EE9486EFC176B0F535A5 /* Pods-Voys.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Voys.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Voys/Pods-Voys.debug.xcconfig"; sourceTree = "<group>"; };
 		7CE771AA34104D7A975041F1 /* libPods-Voys Staging.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Voys Staging.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F8D6569077E6E442EDF57FE /* Pods-Vialer Staging.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Vialer Staging.release.xcconfig"; path = "Pods/Target Support Files/Pods-Vialer Staging/Pods-Vialer Staging.release.xcconfig"; sourceTree = "<group>"; };
+		836884AC20F4B4290098A961 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		8BE353BD30148C20A6FBDC37 /* libPods-VoysSnapshotUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-VoysSnapshotUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9251428B8B3DB22F6FC7F0FD /* Pods-VialerSnapshotUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-VialerSnapshotUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-VialerSnapshotUITests/Pods-VialerSnapshotUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		97BDE05E53D773AA579B4B0C /* Pods-Voys Staging.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Voys Staging.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Voys Staging/Pods-Voys Staging.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1508,6 +1513,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				836884AF20F4B4490098A961 /* CoreBluetooth.framework in Frameworks */,
 				C41FD89B1C60A08400BBE6D7 /* AudioToolbox.framework in Frameworks */,
 				C41FD88F1C60A08400BBE6D7 /* PushKit.framework in Frameworks */,
 				C41FD8911C60A08400BBE6D7 /* SystemConfiguration.framework in Frameworks */,
@@ -1557,6 +1563,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				836884AE20F4B43A0098A961 /* CoreBluetooth.framework in Frameworks */,
 				C490ADAC1D0863E3004A8F83 /* AudioToolbox.framework in Frameworks */,
 				C490ADAD1D0863E3004A8F83 /* PushKit.framework in Frameworks */,
 				C490ADAF1D0863E3004A8F83 /* SystemConfiguration.framework in Frameworks */,
@@ -1600,6 +1607,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				836884AD20F4B4290098A961 /* CoreBluetooth.framework in Frameworks */,
 				EE23186A20A0468F00C05EB0 /* AudioToolbox.framework in Frameworks */,
 				EE23186B20A0468F00C05EB0 /* PushKit.framework in Frameworks */,
 				EE23186C20A0468F00C05EB0 /* SystemConfiguration.framework in Frameworks */,
@@ -1713,6 +1721,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				836884B020F4B4580098A961 /* CoreBluetooth.framework in Frameworks */,
 				FB853166183986A5008A7EF1 /* AudioToolbox.framework in Frameworks */,
 				3D15A4581B2ECAA8004C5012 /* PushKit.framework in Frameworks */,
 				FBB088CA182284A20004FFD1 /* SystemConfiguration.framework in Frameworks */,
@@ -2773,6 +2782,7 @@
 		FB4226CF182261D200707349 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				836884AC20F4B4290098A961 /* CoreBluetooth.framework */,
 				3D15A4571B2ECAA8004C5012 /* PushKit.framework */,
 				F25B39181B08EF43005ED515 /* MobileCoreServices.framework */,
 				FB6B47DD1ABC277600B0DBC4 /* AdSupport.framework */,

--- a/Vialer/AppDelegate.swift
+++ b/Vialer/AppDelegate.swift
@@ -262,6 +262,7 @@ extension AppDelegate {
             case .callCompletedElsewhere:
                 VialerLogDebug("Call completed elsewhere")
                 VialerGAITracker.missedIncomingCallCompletedElsewhereEvent()
+                VialerStats.shared.incomingCallFailedCallCompletedElsewhere()
             case .originatorCancel:
                 VialerLogDebug("Originator cancelled")
                 VialerGAITracker.missedIncomingCallOriginatorCancelledEvent()

--- a/Vialer/Helpers/VialerStats.swift
+++ b/Vialer/Helpers/VialerStats.swift
@@ -234,7 +234,7 @@ import Foundation
     @objc func incomingCallFailedDeclinedBecauseAnotherCallInProgress(call: VSLCall){
         initDefaultData()
         setBluetoothAudioDeviceAndState()
-        
+
         setMiddlewareKey()
         setNetworkData()
         setTransportData()

--- a/Vialer/Helpers/VialerStats.swift
+++ b/Vialer/Helpers/VialerStats.swift
@@ -196,6 +196,20 @@ import Foundation
         
         sendMetrics()
     }
+    
+    @objc func incomingCallFailedCallCompletedElsewhere(){
+        guard !VialerStats.shared.middlewareUniqueKey.isEmpty else {
+            return
+        }
+        self.setNetworkDataAndUniqueKey()
+        
+        defaultData[VialerStatsConstants.APIKeys.direction] = VialerStatsConstants.Direction.inbound
+        defaultData[VialerStatsConstants.APIKeys.callSetupSuccessful] = "false"
+        defaultData[VialerStatsConstants.APIKeys.failedReason] = "CALL_COMPLETED_ELSEWHERE"
+        defaultData.removeValue(forKey: VialerStatsConstants.APIKeys.attempt)
+        
+        sendMetrics()
+    }
 
     @objc func logStatementForReceivedPushNotification(attempt: Int){
         initDefaultData()


### PR DESCRIPTION
### Issue number

VIALI-3477

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix

Added the funtion incomingCallFailedDeclinedBecauseAnotherCallInProgress to the VialerStats class and called it only once in the case of no call-kit is available in AppDelegate

### Other info

{anything else that might be related/useful}
