### PR TITLE
feature/crash-after-logging-in-when-no-phonenumbers-are-available-3405

### DIFF
--- a/Vialer/Contacts/Controllers/ContactsViewController.m
+++ b/Vialer/Contacts/Controllers/ContactsViewController.m
@@ -224,7 +224,6 @@ static NSTimeInterval const ContactsViewControllerReachabilityBarAnimationDurati
         }
         return [self.contactModel contactsAtSection:section - 1].count;
     }
-
     return self.contactModel.searchResult.count;
 }
 
@@ -262,9 +261,16 @@ static NSTimeInterval const ContactsViewControllerReachabilityBarAnimationDurati
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
     if (section == 0 && [tableView isEqual:self.tableView]) {
-        return 1.0f;
+            return 1.0f;
     }
     return 32.0f;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(nonnull NSIndexPath *)indexPath{
+    if ([indexPath section] == 0 && [self.currentUser.outgoingNumber isEqualToString:@""]){
+        return 0;
+    }
+    return UITableViewAutomaticDimension;
 }
 
 #pragma mark - tableview delegate
@@ -368,9 +374,13 @@ static NSTimeInterval const ContactsViewControllerReachabilityBarAnimationDurati
 #pragma mark - Notifications
 
 - (void)outgoingNumberUpdated:(NSNotification *)notification {
-    if (![self.currentUser.outgoingNumber isEqualToString:@""]) {
+    if (![self.currentUser.outgoingNumber isKindOfClass:[NSNull class]]) {
         [self.tableView reloadData];
-        self.myPhoneNumberLabel.text = self.currentUser.outgoingNumber;
+        if (![self.currentUser.outgoingNumber isEqualToString:@""]) {
+            self.myPhoneNumberLabel.text = self.currentUser.outgoingNumber;
+        }
+    } else {
+        self.myPhoneNumberLabel.text = @"";
     }
 }
 

--- a/Vialer/Helpers/VialerLogger.m
+++ b/Vialer/Helpers/VialerLogger.m
@@ -123,6 +123,7 @@ static NSString * const DDLogWrapperShouldUseRemoteLoggingKey = @"DDLogWrapperSh
     logMessage = [logMessage replaceRegexWithPattern:@"nonce=\"(.+?)\"" with:@"NONCE"];
     logMessage = [logMessage replaceRegexWithPattern:@"username=(.+?)&" with: @"USERNAME"];
     logMessage = [logMessage replaceRegexWithPattern:@"token=(.+?)&" with: @"TOKEN"];
+    logMessage = [logMessage replaceRegexWithPattern:@"sip_user_id\" = (.+?);" with:@"<SIP_ANONYMIZED>"];
 
     return logMessage;
 }

--- a/Vialer/Middleware/Middleware.m
+++ b/Vialer/Middleware/Middleware.m
@@ -105,7 +105,6 @@ NSString * const MiddlewareAccountRegistrationIsDoneNotification = @"MiddlewareA
         VialerLogPushNotification(@"iOS : %@\n", payload);
         
         int timeToInitialResponse = ([pushResponseTimeMeasurementStart timeIntervalSince1970] - [[payload valueForKey:@"message_start_time"] doubleValue]) * 1000;
-        VialerLogError(@"%d", timeToInitialResponse);
         [VialerStats sharedInstance].middlewareResponseTime = [NSString stringWithFormat:@"%d", timeToInitialResponse];
 
         NSString *keyToProcess = payload[MiddlewareAPNSPayloadKeyUniqueKey];

--- a/Vialer/Models/SystemUser.m
+++ b/Vialer/Models/SystemUser.m
@@ -331,7 +331,9 @@ static NSString * const SystemUserCurrentAvailabilitySUDKey = @"AvailabilityMode
 - (void)setOutgoingNumber:(NSString *)outgoingNumber {
     if (outgoingNumber != _outgoingNumber) {
         _outgoingNumber = outgoingNumber;
-        [[NSUserDefaults standardUserDefaults] setObject:outgoingNumber forKey:SystemUserSUDOutgoingNumber];
+        if (![outgoingNumber isKindOfClass:[NSNull class]]) {
+            [[NSUserDefaults standardUserDefaults] setObject:outgoingNumber forKey:SystemUserSUDOutgoingNumber];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:SystemUserOutgoingNumberUpdatedNotification object:self];
     }
 }
@@ -608,7 +610,11 @@ static NSString * const SystemUserCurrentAvailabilitySUDKey = @"AvailabilityMode
     self.country = profileDict[SystemUserApiKeyCountry];
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-
+    if ([profileDict[SystemUserApiKeyOutgoingNumber] isKindOfClass:[NSNull class]]) {
+        self.outgoingNumber = @"";
+    } else {
+        self.outgoingNumber = profileDict[SystemUserApiKeyOutgoingNumber];
+    }
     [defaults setObject:self.outgoingNumber forKey:SystemUserSUDOutgoingNumber];
     [defaults setObject:self.country forKey:SystemUserSUDCountry];
 

--- a/Vialer/Onboarding/Controllers/LogInViewController.m
+++ b/Vialer/Onboarding/Controllers/LogInViewController.m
@@ -228,7 +228,26 @@ static NSString * const LoginViewControllerSettingsNavigationControllerStoryboar
 }
 
 - (IBAction)configureViewContinueButtonPressed:(UIButton *)sender {
-    [self continueFromConfigureFormViewToUnlockView];
+    if ([self.configureFormView.outgoingNumberLabel.text isEqualToString:@""]){
+        UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Missing outgoing number", nil)
+                                                                       message:NSLocalizedString(@"Please note that as you don\'t own an outgoing number, you may only call internal numbers",nil)
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
+                                                              handler:^(UIAlertAction * action) {[self continueFromConfigureFormViewToUnlockView];}];
+        
+        UIAlertAction* cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault
+                                                              handler:^(UIAlertAction * action) {}];
+        
+        [alert addAction:defaultAction];
+        [alert addAction:cancelAction];
+        [self presentViewController:alert animated:YES completion:nil];
+    } else {
+        [self continueFromConfigureFormViewToUnlockView];
+    }
+    
+    
+    
 }
 
 - (IBAction)twoFactorAuthenticationViewContinueButtonPressed:(UIButton *)sender {
@@ -557,7 +576,13 @@ static NSString * const LoginViewControllerSettingsNavigationControllerStoryboar
 
         if (!error) {
             SystemUser *systemUser = [SystemUser currentUser];
-            self.configureFormView.outgoingNumberLabel.text = systemUser.outgoingNumber;
+            if ([systemUser.outgoingNumber isKindOfClass:[NSNull class]] || [systemUser.outgoingNumber isEqualToString:@""])
+            {
+                self.configureFormView.outgoingNumberLabel.text = @"";
+                self.configureFormView.outgoingNumberDescriptionField.text = @"";
+            } else {
+                self.configureFormView.outgoingNumberLabel.text = systemUser.outgoingNumber;
+            }
             self.configureFormView.phoneNumberField.text = systemUser.mobileNumber;
             self.unlockView.greetingsLabel.text = systemUser.displayName;
 

--- a/Vialer/nl.lproj/Localizable.strings
+++ b/Vialer/nl.lproj/Localizable.strings
@@ -283,7 +283,13 @@
 "Please enter a valid email address." = "Vul een geldig e-mailadres in.";
 
 /* No comment provided by engineer. */
-"Please enter your e-mail address and we will send you instructions on setting a new password." = "Geef je e-mailadres op, dan sturen we de instructies voor het instellen van een nieuw wachtwoord.";
+"Missing outgoing number" = "Uitgaand nummer ontbreekt";
+
+/* No comment provided by engineer. */
+"Please note that as you don\'t own an outgoing number, you may only call internal numbers" = "Vanwege het ontbreken van een uitgaand nummer kan je alleen interne nummers bellen";
+
+/* No comment provided by engineer. */
+"Please enter your e-mail address and we will send you instructions on setting a new password" = "Geef je e-mailadres op, dan sturen we de instructies voor het instellen van een nieuw wachtwoord.";
 
 /* No comment provided by engineer. */
 "Please enter your mobile number here." = "Voer hier je mobiele telefoonnummer in.";


### PR DESCRIPTION
…d changed the relevant UI accordingly

VIALI-3405

{if exists provide related issue}

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix

Made the outgoing number not mandatory, solved the exception cases and changed the relevant UI accordingly

### Other info

{anything else that might be related/useful}
