### PR TITLE
VIALI-3526: Make the device manufacturer apple

### DIFF
--- a/Vialer/Helpers/VialerStats.swift
+++ b/Vialer/Helpers/VialerStats.swift
@@ -122,7 +122,7 @@ import Foundation
         defaultData = [
             VialerStatsConstants.APIKeys.sipUserId: SystemUser.current().sipAccount,
             VialerStatsConstants.APIKeys.os: "iOS",
-            VialerStatsConstants.APIKeys.deviceManufacturer: UIDevice.current.model,
+            VialerStatsConstants.APIKeys.deviceManufacturer: "Apple",
             VialerStatsConstants.APIKeys.deviceModel: UIDevice.current.modelName.replacingOccurrences(of: UIDevice.current.model, with: ""),
             VialerStatsConstants.APIKeys.osVersion: VialerStatsConstants.osVersion,
             VialerStatsConstants.APIKeys.appVersion: VialerStatsConstants.appVersion,


### PR DESCRIPTION
### Issue number
VIALI-3526

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix

Made the device manufacturer apple

### Other info

On android is 'device_manufacturer': 'samsung'
