### PR TITLE
feature/fix-the-iphoneX-UX-3520

### DIFF
--- a/Vialer/Main/Controllers/VailerRootViewController.m
+++ b/Vialer/Main/Controllers/VailerRootViewController.m
@@ -134,8 +134,11 @@ static NSString * const VialerRootViewControllerShowTwoStepCallingViewSegue = @"
 - (void)setupLayout {
     NSString *launchImage;
     CGFloat screenHeight = [UIScreen mainScreen].bounds.size.height;
-
-    if(screenHeight > 667.0f) {
+    
+    if(screenHeight > 736.0f) {
+        launchImage = @"LaunchImage-1100-Portrait-2436h"; // iphone-x
+    }
+    else if(screenHeight > 667.0f) {
         launchImage = @"LaunchImage-800-Portrait-736h"; // iphone6 plus
     }
     else if(screenHeight > 568.0f) {


### PR DESCRIPTION
### Issue number

VIALI-3520

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix

Fixed the launch screen for iphone-x

### Other info
On VailerRootViewController.m/setupLayout:134 invalid names of launch screens are used like "LaunchImage-800-Portrait-736h" There is no file or object in the project that has any of these names. Should I change them to the existing ones found at ../Vialer/iOS/vialer-ios/Branding/Vialer/Vialer.xcassets/LaunchImage.launchimage ? They seem to be ok for now  as the system loads them(?!) but I guess their names should be updated in the code to avoid any unwanted behaviour.

Additionally I have searched the app for the iphone-x's flaw on creating contact screen sent by Remi but on the simulator everything seems fine. I asked details from him but still no answer. Maybe that issue was already fixed?

![simulator screen shot - iphone x - 2018-08-08 at 17 41 26](https://user-images.githubusercontent.com/38938642/43899957-c4b74516-9be3-11e8-88ca-24ee5a3a1345.png)
 
Let me know what you think about all these.