### PR TITLE
feature/app-crashing-when-the-app-acount-is-empty-3542

### DIFF
--- a/Vialer/Models/SystemUser.m
+++ b/Vialer/Models/SystemUser.m
@@ -616,7 +616,9 @@ static NSString * const SystemUserCurrentAvailabilitySUDKey = @"AvailabilityMode
         self.outgoingNumber = profileDict[SystemUserApiKeyOutgoingNumber];
     }
     [defaults setObject:self.outgoingNumber forKey:SystemUserSUDOutgoingNumber];
-    [defaults setObject:self.country forKey:SystemUserSUDCountry];
+    if (![self.country isKindOfClass:[NSNull class]]) {
+        [defaults setObject:self.country forKey:SystemUserSUDCountry];
+    }
 
     [defaults synchronize];
 }


### PR DESCRIPTION
### Issue number
VIALI-3542

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix
Added a check to country property to avoid assigning null value

### Other info

{anything else that might be related/useful}
